### PR TITLE
Update Comparator functions to use [LT, EQ, GT] instead of I64

### DIFF
--- a/package/Compare.roc
+++ b/package/Compare.roc
@@ -1,20 +1,24 @@
 module [compareNum, reverseNum, compareStr, reverseStr]
 
-compareNum : Num a, Num a -> I64
-compareNum = \a, b -> if a < b then -1 else if a > b then 1 else 0
+compareNum : Num a, Num a -> [LT, EQ, GT]
+compareNum = \a, b -> if a < b then LT else if a > b then GT else EQ
 
-reverseNum : Num a, Num a -> I64
+reverseNum : Num a, Num a -> [LT, EQ, GT]
 reverseNum = \a, b -> compareNum b a
 
-compareStr : Str, Str -> I64
+compareStr : Str, Str -> [LT, EQ, GT]
 compareStr = \a, b -> 
-    if a == b then 0
+    if a == b then EQ
     else
         bytesA = Str.toUtf8 a
         bytesB = Str.toUtf8 b
         compList = List.map2 bytesA bytesB \byteA, byteB ->
-            if byteA < byteB then -1 else if byteA > byteB then 1 else 0
-        (List.findFirst compList \comp -> comp != 0) |> Result.withDefault (Num.toI64 (List.len bytesA) - Num.toI64 (List.len bytesB))
+            if byteA < byteB then LT else if byteA > byteB then GT else EQ
+        (List.findFirst compList \comp -> comp != EQ) 
+        |> Result.withDefault (Num.toI64 (List.len bytesA) - Num.toI64 (List.len bytesB) |> numToComparator)
     
-reverseStr : Str, Str -> I64
+reverseStr : Str, Str -> [LT, EQ, GT]
 reverseStr = \a, b -> compareStr b a
+
+numToComparator : Num a -> [LT, EQ, GT]
+numToComparator = \n -> if n < 0 then LT else if n > 0 then GT else EQ

--- a/package/Test.roc
+++ b/package/Test.roc
@@ -41,6 +41,9 @@ expect
 expect 
     quicksort ["a", "A", "!", "0"] compareStr == ["!", "0", "A", "a"]
     && quicksort ["a", "A", "!", "0"] reverseStr == ["a", "A", "0", "!"]
+expect
+    quicksort ["A", "a", "a", "A"] compareStr == ["A", "A", "a", "a"]
+    && quicksort ["A", "a", "a", "A"] reverseStr == ["a", "a", "A", "A"]
 expect 
     sorted = quicksort ["hello world", "hello, world", "Hello, world", "Hello, World", "hello, world!", "Hello, world!", "Hello, World!", "\"Hello, World!\""] compareStr 
     sorted == ["\"Hello, World!\"", "Hello, World", "Hello, World!", "Hello, world", "Hello, world!", "hello world", "hello, world", "hello, world!"]
@@ -83,6 +86,9 @@ expect
 expect
     mergesort ["a", "A", "!", "0"] compareStr == ["!", "0", "A", "a"]
     && mergesort ["a", "A", "!", "0"] reverseStr == ["a", "A", "0", "!"]
+expect
+    mergesort ["A", "a", "a", "A"] compareStr == ["A", "A", "a", "a"]
+    && mergesort ["A", "a", "a", "A"] reverseStr == ["a", "a", "A", "A"]
 expect
     sorted = mergesort ["hello world", "hello, world", "Hello, world", "Hello, World", "hello, world!", "Hello, world!", "Hello, World!", "\"Hello, World!\""] compareStr
     sorted == ["\"Hello, World!\"", "Hello, World", "Hello, World!", "Hello, world", "Hello, world!", "hello world", "hello, world", "hello, world!"]


### PR DESCRIPTION
- This will make the comparators compatible with sortWith in the roc built in List function.